### PR TITLE
Fix single-click week view transition

### DIFF
--- a/src/main/java/UI/CalendarUI/view/MonthView.java
+++ b/src/main/java/UI/CalendarUI/view/MonthView.java
@@ -120,11 +120,9 @@ public class MonthView extends JPanel {
                         if (!dayText.isEmpty()) {
                             LocalDate selectedDate = LocalDate.of(currentYear, currentMonth, Integer.parseInt(dayText));
 
-                            // 雙擊進入週視圖並彈出新事件對話框，單擊選擇日期
+                            // 單擊切換到週視圖
                             if (e.getClickCount() == 1) {
-                                controller.handleWeekSelectedWithNewEvent(selectedDate);
-                            } else {
-                                controller.handleDateSelected(selectedDate);
+                                controller.handleWeekSelected(selectedDate);
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- simplify day click in `MonthView` to switch to week view
- ensure `handleWeekSelected` switches week view through `viewSwitcher`

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684699804870832cb1b8429692bdfe46