### PR TITLE
Rename Event class to EventInfo

### DIFF
--- a/src/main/java/UI/CalendarUI/service/EventInfo.java
+++ b/src/main/java/UI/CalendarUI/service/EventInfo.java
@@ -1,6 +1,6 @@
 package UI.CalendarUI.service;
 
-public class Event {
+public class EventInfo {
     public String summary;
     public DateTimeWrapper start;
     public DateTimeWrapper end;

--- a/src/main/java/UI/CalendarUI/service/JsonService.java
+++ b/src/main/java/UI/CalendarUI/service/JsonService.java
@@ -1,6 +1,6 @@
 package UI.CalendarUI.service;
 
-import UI.CalendarUI.service.Event;
+import UI.CalendarUI.service.EventInfo;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import java.io.FileNotFoundException;
@@ -26,21 +26,21 @@ public class JsonService {
     }
 
     public void getEventInfo(){
-        Type listType = new TypeToken<List<Event>>(){}.getType();
-        List<Event> ListEvents = gson.fromJson(reader, listType);
+        Type listType = new TypeToken<List<EventInfo>>(){}.getType();
+        List<EventInfo> ListEvents = gson.fromJson(reader, listType);
 
-        for (Event e  : ListEvents){
+        for (EventInfo e  : ListEvents){
             System.out.println("Summary: " + e.summary + " Start value " + e.start.dateTime.value + " End value " + e.end.dateTime.value);
         }
     }
 
     // 新增：獲取所有事件的方法
-    public List<Event> getAllEvents() {
+    public List<EventInfo> getAllEvents() {
         try {
             // 每次調用都重新創建 FileReader，確保讀取最新資料
             FileReader reader = new FileReader(EVENTS_FILE_PATH);
-            Type listType = new TypeToken<List<Event>>(){}.getType();
-            List<Event> events = gson.fromJson(reader, listType);
+            Type listType = new TypeToken<List<EventInfo>>(){}.getType();
+            List<EventInfo> events = gson.fromJson(reader, listType);
             reader.close();
 
             return events != null ? events : new ArrayList<>();

--- a/src/main/java/UI/CalendarUI/view/MonthView.java
+++ b/src/main/java/UI/CalendarUI/view/MonthView.java
@@ -15,7 +15,7 @@ import java.util.List;
 import UI.CalendarUI.controller.CalendarController;
 import UI.CalendarUI.utils.DateUtils;
 import UI.CalendarUI.service.JsonService;
-import UI.CalendarUI.service.Event;
+import UI.CalendarUI.service.EventInfo;
 
 public class MonthView extends JPanel {
 
@@ -156,7 +156,7 @@ public class MonthView extends JPanel {
         Object[][] cells = new Object[6][7];
 
         // 獲取所有事件
-        List<Event> allEvents = jsonService.getAllEvents();
+        List<EventInfo> allEvents = jsonService.getAllEvents();
 
         int dayCounter = 1;
         for (int row = 0; row < 6; row++) {
@@ -185,7 +185,7 @@ public class MonthView extends JPanel {
     }
 
     // 新增：創建包含日期和事件的面板
-    private JPanel createDayPanel(int day, List<Event> events) {
+    private JPanel createDayPanel(int day, List<EventInfo> events) {
         JPanel panel = new JPanel();
         panel.setLayout(new BorderLayout());
         panel.setBackground(Color.WHITE);
@@ -205,7 +205,7 @@ public class MonthView extends JPanel {
             // 最多顯示3個事件，避免過度擁擠
             int maxEventsToShow = Math.min(events.size(), 3);
             for (int i = 0; i < maxEventsToShow; i++) {
-                Event event = events.get(i);
+                EventInfo event = events.get(i);
                 JLabel eventLabel = new JLabel(event.summary);
                 // 新增 putClientProperty 方法，讓panel標註事件ID用於刪除
                 eventLabel.putClientProperty("id", event.id);
@@ -232,7 +232,7 @@ public class MonthView extends JPanel {
     }
 
     // 新增：獲取指定日期的事件
-    private List<Event> getEventsForDate(List<Event> allEvents, LocalDate date) {
+    private List<EventInfo> getEventsForDate(List<EventInfo> allEvents, LocalDate date) {
         return allEvents.stream()
                 .filter(event -> {
                     // 將事件的時間戳轉換為 LocalDate

--- a/src/main/java/UI/CalendarUI/view/WeekView.java
+++ b/src/main/java/UI/CalendarUI/view/WeekView.java
@@ -18,7 +18,7 @@ import java.util.ArrayList;
 
 import UI.CalendarUI.controller.CalendarController;
 import UI.CalendarUI.service.JsonService;
-import UI.CalendarUI.service.Event;
+import UI.CalendarUI.service.EventInfo;
 
 public class WeekView extends JPanel {
 
@@ -116,7 +116,7 @@ public class WeekView extends JPanel {
                         Object eventsObj = panel.getClientProperty("events");
                         if (eventsObj instanceof List) {
                             @SuppressWarnings("unchecked")
-                            List<Event> events = (List<Event>) eventsObj;
+                            List<EventInfo> events = (List<EventInfo>) eventsObj;
                             controller.showEventDialog(selectedDate, events);
                         }
                     } else {
@@ -144,8 +144,8 @@ public class WeekView extends JPanel {
         weekLabel.setText(weekRange);
 
         // 獲取本週的所有事件
-        List<Event> allEvents = jsonService.getAllEvents();
-        List<Event> weekEvents = getEventsForWeek(allEvents, startOfWeek);
+        List<EventInfo> allEvents = jsonService.getAllEvents();
+        List<EventInfo> weekEvents = getEventsForWeek(allEvents, startOfWeek);
 
         tableModel.setRowCount(0);
         for (int hour = 0; hour < 24; hour++) {
@@ -155,7 +155,7 @@ public class WeekView extends JPanel {
             // 為每一天檢查是否有事件
             for (int dayIndex = 0; dayIndex < 7; dayIndex++) {
                 LocalDate currentDate = startOfWeek.plusDays(dayIndex);
-                List<Event> dayHourEvents = getEventsForDateAndHour(weekEvents, currentDate, hour);
+                List<EventInfo> dayHourEvents = getEventsForDateAndHour(weekEvents, currentDate, hour);
 
                 if (!dayHourEvents.isEmpty()) {
                     row[dayIndex + 1] = createEventCellContent(dayHourEvents, currentDate);
@@ -168,7 +168,7 @@ public class WeekView extends JPanel {
     }
 
     // 新增：獲取指定週的所有事件
-    private List<Event> getEventsForWeek(List<Event> allEvents, LocalDate weekStart) {
+    private List<EventInfo> getEventsForWeek(List<EventInfo> allEvents, LocalDate weekStart) {
         LocalDate weekEnd = weekStart.plusDays(6);
         return allEvents.stream()
                 .filter(event -> {
@@ -181,7 +181,7 @@ public class WeekView extends JPanel {
     }
 
     // 新增：獲取指定日期和小時的事件
-    private List<Event> getEventsForDateAndHour(List<Event> events, LocalDate date, int hour) {
+    private List<EventInfo> getEventsForDateAndHour(List<EventInfo> events, LocalDate date, int hour) {
         return events.stream()
                 .filter(event -> {
                     LocalDateTime eventDateTime = Instant.ofEpochMilli(event.start.dateTime.value)
@@ -214,7 +214,7 @@ public class WeekView extends JPanel {
     }
 
     // 新增：創建事件儲存格內容
-    private JPanel createEventCellContent(List<Event> events, LocalDate date) {
+    private JPanel createEventCellContent(List<EventInfo> events, LocalDate date) {
         JPanel panel = new JPanel();
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
         panel.setBackground(Color.WHITE);
@@ -223,7 +223,7 @@ public class WeekView extends JPanel {
         // 最多顯示2個事件，避免過度擁擠
         int maxEventsToShow = Math.min(events.size(), 2);
         for (int i = 0; i < maxEventsToShow; i++) {
-            Event event = events.get(i);
+            EventInfo event = events.get(i);
 
             // 格式化事件顯示
             LocalDateTime startTime = Instant.ofEpochMilli(event.start.dateTime.value)


### PR DESCRIPTION
## Summary
- avoid collision with Google API `Event` by renaming our JSON event POJO from `Event` to `EventInfo`
- update usages in `JsonService`, `WeekView` and `MonthView`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6846ae5e2468832cb9d4a6d265d4ea52