### PR TITLE
Add AI arrange checkbox in NewEventDialog

### DIFF
--- a/src/main/java/UI/CalendarUI/controller/CalendarController.java
+++ b/src/main/java/UI/CalendarUI/controller/CalendarController.java
@@ -1,6 +1,5 @@
 package UI.CalendarUI.controller;
 
-import UI.AIArrangeUI;
 import UI.CalendarUI.model.CalendarModel;
 import UI.CalendarUI.service.EventInfo;
 import UI.CalendarUI.service.EventService;
@@ -103,14 +102,11 @@ public class CalendarController {
     }
 
     public void showNewEventDialog(LocalDate date) {
-        JCheckBox aiCheckBox = new JCheckBox("Arrange by AI");
-
         NewEventDialog dialog = new NewEventDialog(
                 SwingUtilities.getWindowAncestor(parentComponent),
                 date,
                 (summary, location, description, d, startTime, endTime) -> {
                     try {
-                        boolean arrangeByAI = aiCheckBox.isSelected();
                         ZoneId zoneId = ZoneId.systemDefault();
                         ZonedDateTime startDateTime = ZonedDateTime.of(d, java.time.LocalTime.parse(startTime), zoneId);
                         ZonedDateTime endDateTime = ZonedDateTime.of(d, java.time.LocalTime.parse(endTime), zoneId);
@@ -120,10 +116,6 @@ public class CalendarController {
 
                         Event newEvent = service.createEvent(summary, location, description, startRfc3339, endRfc3339);
                         service.insertEvent(newEvent);
-                        if (arrangeByAI) {
-                            AIArrangeUI aiArrangeUI = new AIArrangeUI(summary);
-                            aiArrangeUI.setVisible(true);//TODO AI行程安排視窗fetch and save events
-                        }
                         service.fetchAndSaveEvents();
 
                         List<Event> updatedEvents = service.getEventsOnDate(d);
@@ -139,7 +131,6 @@ public class CalendarController {
                 }
         );
 
-        dialog.add(aiCheckBox, BorderLayout.SOUTH);
         dialog.setVisible(true);
     }
 

--- a/src/main/java/UI/CalendarUI/view/dialogs/NewEventDialog.java
+++ b/src/main/java/UI/CalendarUI/view/dialogs/NewEventDialog.java
@@ -1,5 +1,6 @@
 package UI.CalendarUI.view.dialogs;
 
+import UI.AIArrangeUI;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -14,6 +15,7 @@ public class NewEventDialog extends JDialog {
     private JList<String> timeList;
     private JButton saveButton;
     private JButton cancelButton;
+    private JCheckBox aiCheckBox;
     private LocalDate date;
 
     public interface EventSaveListener {
@@ -62,6 +64,7 @@ public class NewEventDialog extends JDialog {
         JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
         saveButton = new JButton("Save");
         cancelButton = new JButton("Cancel");
+        aiCheckBox = new JCheckBox("Arrange by AI");
 
         saveButton.addActionListener((ActionEvent e) -> {
             String summary = summaryField.getText().trim();
@@ -83,11 +86,16 @@ public class NewEventDialog extends JDialog {
             String endTime = selectedTimes.get(selectedTimes.size() - 1);
 
             listener.onSave(summary, location, desc, date, startTime, endTime);
+            if (aiCheckBox.isSelected()) {
+                AIArrangeUI aiArrangeUI = new AIArrangeUI(summary);
+                aiArrangeUI.setVisible(true);
+            }
             dispose();
         });
 
         cancelButton.addActionListener(e -> dispose());
 
+        buttonPanel.add(aiCheckBox);
         buttonPanel.add(cancelButton);
         buttonPanel.add(saveButton);
         panel.add(buttonPanel, BorderLayout.SOUTH);


### PR DESCRIPTION
## Summary
- integrate AI arrange checkbox directly into `NewEventDialog`
- trigger `AIArrangeUI` when the checkbox is selected after saving
- simplify `CalendarController.showNewEventDialog` accordingly

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684715ad9298832cb68b8e3bbc0f235c